### PR TITLE
Ajout de la connexion (login) via l'API Discogs

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -28,3 +28,10 @@ group :development, :test do
   gem 'spring-watcher-listen', '~> 2.0.0'
   gem 'dotenv-rails'
 end
+
+#Owngems
+
+gem 'omniauth-oauth'
+gem 'omniauth-discogs'
+gem 'discogs-wrapper'
+gem 'activerecord-session_store'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -33,6 +33,12 @@ GEM
       activemodel (= 5.2.3)
       activesupport (= 5.2.3)
       arel (>= 9.0)
+    activerecord-session_store (1.1.3)
+      actionpack (>= 4.0)
+      activerecord (>= 4.0)
+      multi_json (~> 1.11, >= 1.11.2)
+      rack (>= 1.5.2, < 3)
+      railties (>= 4.0)
     activestorage (5.2.3)
       actionpack (= 5.2.3)
       activerecord (= 5.2.3)
@@ -60,6 +66,10 @@ GEM
       railties (>= 4.1.0, < 6.0)
       responders
       warden (~> 1.2.3)
+    discogs-wrapper (2.5.0)
+      hashie (~> 3.0)
+      httparty (~> 0.14)
+      oauth (~> 0.5.1)
     dotenv (2.7.5)
     dotenv-rails (2.7.5)
       dotenv (= 2.7.5)
@@ -71,6 +81,10 @@ GEM
       sassc (>= 1.11)
     globalid (0.4.2)
       activesupport (>= 4.2.0)
+    hashie (3.6.0)
+    httparty (0.17.0)
+      mime-types (~> 3.0)
+      multi_xml (>= 0.5.2)
     i18n (1.6.0)
       concurrent-ruby (~> 1.0)
     jbuilder (2.9.1)
@@ -86,14 +100,28 @@ GEM
     marcel (0.3.3)
       mimemagic (~> 0.3.2)
     method_source (0.9.2)
+    mime-types (3.2.2)
+      mime-types-data (~> 3.2015)
+    mime-types-data (3.2019.0331)
     mimemagic (0.3.3)
     mini_mime (1.0.2)
     mini_portile2 (2.4.0)
     minitest (5.11.3)
     msgpack (1.3.1)
+    multi_json (1.13.1)
+    multi_xml (0.6.0)
     nio4r (2.4.0)
     nokogiri (1.10.4)
       mini_portile2 (~> 2.4.0)
+    oauth (0.5.4)
+    omniauth (1.9.0)
+      hashie (>= 3.4.6, < 3.7.0)
+      rack (>= 1.6.2, < 3)
+    omniauth-discogs (0.0.4)
+      omniauth-oauth (~> 1.0)
+    omniauth-oauth (1.1.0)
+      oauth
+      omniauth (~> 1.0)
     orm_adapter (0.5.0)
     pg (0.21.0)
     pry (0.12.2)
@@ -191,13 +219,17 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
+  activerecord-session_store
   autoprefixer-rails
   bootsnap
   devise
+  discogs-wrapper
   dotenv-rails
   font-awesome-sass (~> 5.6.1)
   jbuilder (~> 2.0)
   listen (~> 3.0.5)
+  omniauth-discogs
+  omniauth-oauth
   pg (~> 0.21)
   pry-byebug
   pry-rails

--- a/app/controllers/users/omniauth_callbacks_controller.rb
+++ b/app/controllers/users/omniauth_callbacks_controller.rb
@@ -1,0 +1,14 @@
+class Users::OmniauthCallbacksController < Devise::OmniauthCallbacksController
+  def discogs
+    user = User.find_for_discogs_oauth(request.env['omniauth.auth'])
+
+    if user.persisted?
+      session[:access_token] = request.env['omniauth.auth'].extra.access_token
+      sign_in_and_redirect user, event: :authentication
+      set_flash_message(:notice, :success, kind: 'Discogs') if is_navigational_format?
+    else
+      session['devise.discogs_data'] = request.env['omniauth.auth']
+      redirect_to new_user_registration_url
+    end
+  end
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -2,5 +2,28 @@ class User < ApplicationRecord
   # Include default devise modules. Others available are:
   # :confirmable, :lockable, :timeoutable, :trackable and :omniauthable
   devise :database_authenticatable, :registerable,
-         :recoverable, :rememberable, :validatable
+         :recoverable, :rememberable, :validatable, :omniauthable
+
+  def self.find_for_discogs_oauth(auth)
+    user_params = {
+      username:   auth.info.username,
+      avatar:     auth.info.picture,
+      email:      auth.info.username.downcase + '@diggerz-user.com',
+      discogs_id: auth.uid,
+      provider:   auth.provider,
+      token:      auth.credentials.token
+    }
+
+    user = User.find_by(provider: auth.provider, discogs_id: auth.uid)
+    user ||= User.find_by(email: user_params["email"]) # User did a regular sign up in the past.
+
+    if user
+      user.update(user_params)
+    else
+      user = User.new(user_params)
+      user.password = Devise.friendly_token[0,20]  # Fake password for validation
+      user.save!
+    end
+    return user
+  end
 end

--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -9,7 +9,9 @@ Devise.setup do |config|
   # Devise will use the `secret_key_base` as its `secret_key`
   # by default. You can change it below and use your own secret key.
   # config.secret_key = '25c65b4715c91245fedcb2006142b4c6e062bd3b6a42e87dfdd52a4de5d72f7ae8120a5442c60622181ba8fceb60e2689642b526756c670bda3e9aa0ef0e7d90'
-
+  config.omniauth :discogs, ENV["DISCOGS_API_KEY"], ENV["DISCOGS_API_SECRET"],
+    scope: 'email',
+    info_fields: 'email, first_name, last_name'
   # ==> Controller configuration
   # Configure the parent class to the devise controllers.
   # config.parent_controller = 'DeviseController'

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,7 +1,8 @@
 Rails.application.routes.draw do
   root to: 'pages#home'
 
-  devise_for :users
+  devise_for :users,
+    controllers: { omniauth_callbacks: 'users/omniauth_callbacks' }
 
   resources :deals, only: [:index, :show] do
     member do

--- a/db/migrate/20190820151158_add_discogs_columns_to_users.rb
+++ b/db/migrate/20190820151158_add_discogs_columns_to_users.rb
@@ -1,0 +1,7 @@
+class AddDiscogsColumnsToUsers < ActiveRecord::Migration[5.2]
+  def change
+    add_column :users, :provider, :string
+    add_column :users, :discogs_id, :string
+    add_column :users, :token, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_08_19_171558) do
+ActiveRecord::Schema.define(version: 2019_08_20_151158) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -85,6 +85,9 @@ ActiveRecord::Schema.define(version: 2019_08_19_171558) do
     t.string "username"
     t.string "name"
     t.string "location"
+    t.string "provider"
+    t.string "discogs_id"
+    t.string "token"
     t.index ["email"], name: "index_users_on_email", unique: true
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true
   end


### PR DESCRIPTION
Pour l'instant, front de la page de login non retouché,
La possibilité de se connecter avec des identifiants / mot de passe hors Discogs est toujours présente : sera à enlever quand on on travaillera sur le visuel de la page de login. 