### PR TITLE
Parametrage_signin_button_on_homepage

### DIFF
--- a/app/views/pages/home.html.erb
+++ b/app/views/pages/home.html.erb
@@ -2,9 +2,14 @@
   <div class="homepage-container">
     <%= image_tag "logo_diggerz_full_white.png"%>
     <p>Hidden gems around you.</p>
-    <div class="button-master"> <%= link_to root_path do %>
-        <%= image_tag "logo_diggerz_icon_white.png"%>
-        S'inscrire avec Discogs
+    <div class="button-master">
+      <% if user_signed_in? %>
+        <%= link_to "My records", myrecords_path %>
+      <% else %>
+        <%= link_to user_discogs_omniauth_authorize_path, method: :post do %>
+          <%= image_tag "logo_diggerz_icon_white.png"%>
+          Se connecter avec Discogs
+        <% end %>
       <% end %>
     </div>
   </div>


### PR DESCRIPTION
Paramétrage du bouton de connexion "Se connecter via Discogs" sur la page d'accueil.

--> Si jamais l'user est déjà connecté, il lui est proposé d'afficher "My records" plutôt que "Se connecter" sinon on tourne en rond .. A voir si on maintien "My records" --> plutôt "My deals".