### PR TITLE
Ajout datas à importer pour afficher la collection dans myrecord + aj…

### DIFF
--- a/app/controllers/myrecords_controller.rb
+++ b/app/controllers/myrecords_controller.rb
@@ -1,14 +1,32 @@
 class MyrecordsController < ApplicationController
+  before_action :set_discogs, only: [:show, :import_from_discogs]
+
   def index
     @records = current_user.records.includes(:release)
   end
 
+  def show
+    @record = Record.find(params[:id])
+
+    if @record.release.tracks.empty?
+      ImportReleaseDataFromDiscogs.new(@discogs, release: @record.release).import_release_data
+    end
+  end
+
   def import_from_discogs
-    @discogs = Discogs::Wrapper.new("Diggerz", access_token: session[:access_token])
+    imported = ImportCollectionFromDiscogsService.new(@discogs, user: current_user).import_collection
 
-    ImportCollectionFromDiscogsService.new(current_user, @discogs).call
-
-    redirect_to myrecords_path, notice: "Succesfully imported Discogs' collection"
+    if imported
+      redirect_to myrecords_path, notice: "Succesfully imported Discogs' collection"
+    else
+      redirect_to myrecords_path, alert: "Something went wrong"
+    end
     # <%= link_to 'Importer ma collection', import_from_discogs_releases_path %>
+  end
+
+  private
+
+  def set_discogs
+    @discogs = Discogs::Wrapper.new("Diggerz", access_token: session[:access_token])
   end
 end

--- a/app/models/release.rb
+++ b/app/models/release.rb
@@ -6,5 +6,4 @@ class Release < ApplicationRecord
   has_many :tracks
   has_many :records
   has_many :deals, through: :records
-
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -2,6 +2,7 @@ class User < ApplicationRecord
   # Include default devise modules. Others available are:
   # :confirmable, :lockable, :timeoutable, :trackable and :omniauthable
   has_many :records
+  has_many :releases, through: :records
   has_many :preferences
   has_many :genres, through: :preferences
 

--- a/app/services/import_collection_from_discogs_service.rb
+++ b/app/services/import_collection_from_discogs_service.rb
@@ -1,36 +1,48 @@
 class ImportCollectionFromDiscogsService
-  def initialize(user, discogs)
-    @user = user
+  def initialize(discogs, params = {})
     @discogs = discogs
+    @user = params[:user]
+    @release = params[:release]
   end
 
-  def call
+  def import_release_data
+
+  end
+
+  def import_collection
     @releases = @discogs.get_user_collection(@user.username).releases
 
     @releases.each do |discogs_release|
+      next unless discogs_release.basic_information.formats.first.name == "Vinyl"
+
+      release_params = {
+        title: discogs_release.basic_information.title,
+        artist: discogs_release.basic_information.artists.first.name,
+        discogs_id: discogs_release.id,
+        genre: Genre.first,
+        year: discogs_release.basic_information.year,
+        label: discogs_release.basic_information.labels.first.name
+      }
+
       diggerz_release = Release.find_by(discogs_id: discogs_release.id)
-      binding.pry
 
       if diggerz_release.nil?
-        diggerz_release = Release.new(
-          title: discogs_release.basic_information.title,
-          artist: discogs_release.basic_information.artists.first.name,
-          discogs_id: discogs_release.id,
-          genre: Genre.find
-        )
-        diggerz_release.save
+        diggerz_release = Release.new(release_params)
+        diggerz_release.remote_image_url = discogs_release.basic_information.cover_image
+      else
+        diggerz_release.update_attributes(release_params)
       end
 
-      if diggerz_release.persisted?
-        record = Record.find_by(user: @user, release: diggerz_release)
-        if record.nil?
-          record = Record.new(
-            user: @user,
-            release: diggerz_release
-          )
-          record.save
-        end
-      end
+      return false unless diggerz_release.save
+
+      next if Record.find_by(user: @user, release: diggerz_release)
+
+      record = Record.new(
+        user: @user,
+        release: diggerz_release
+      )
+      return false unless record.save
     end
+    return true
   end
 end

--- a/app/views/myrecords/index.html.erb
+++ b/app/views/myrecords/index.html.erb
@@ -1,7 +1,0 @@
-<ul>
-  <% @records.each do |record| %>
-    <li><%= record.release.title %></li>
-  <% end %>
-</ul>
-
-<%= link_to 'Synchroniser ma collection Discogs', import_from_discogs_myrecords_path %>


### PR DESCRIPTION
Ajout de datas à importer depuis l'API pour afficher la collection dans myrecords (images via clevercloud)
--> Reste à gérer le souci de récupération du genre
Ajout d'un has many releases through records dans le model User. 
Paramétrage OK pour ne récupérer que les éléments dont le format est "vinyl"
Gestion d'un update des datas de la collection (my records) lorsque l'user clique sur "Synchroniser ma collection" --> seules les nouvelles données sont importées. 
Compilation dans un seul fichier des méthodes permettant de récupérer les datas de l'api pour la collection (myrecords #index), pour les records (record #show) et le profil --> gestion du controlleur myrecords uniquement pour le moment. A suivre : le profil et les records. 

Stockage ci dessous pour mémoire du test d'affichage dans l'index de myrecords (pour éviter un doublon avec la page préparée par Yanis) --> pas d'intérêt à l'avoir dans ma pull request car ne contenait pas de front. 
<ul>
  <% @records.each do |record| %>
    <li><%= record.release.title %> - Artist : <%= record.release.artist %> - Year : <%= record.release.year %> - Label : <%= record.release.label %> - Image : <%= cl_image_tag record.release.image, crop: :fill, width: 100, height: 100  %></li>
  <% end %>
</ul>
<%= link_to 'Synchroniser ma collection Discogs', import_from_discogs_myrecords_path %>