### PR TITLE
Suppression de la colonne Image de la table Genres qui ne servait à rien

### DIFF
--- a/db/migrate/20190828173104_remove_image_from_genres_table.rb
+++ b/db/migrate/20190828173104_remove_image_from_genres_table.rb
@@ -1,0 +1,5 @@
+class RemoveImageFromGenresTable < ActiveRecord::Migration[5.2]
+  def change
+    remove_column :genres, :image, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_08_28_100544) do
+ActiveRecord::Schema.define(version: 2019_08_28_173104) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -44,7 +44,6 @@ ActiveRecord::Schema.define(version: 2019_08_28_100544) do
     t.string "name"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-    t.string "image"
   end
 
   create_table "preferences", force: :cascade do |t|

--- a/tt
+++ b/tt
@@ -1,0 +1,11 @@
+[1mdiff --git a/app/assets/stylesheets/components/_button.scss b/app/assets/stylesheets/components/_button.scss[m
+[1mindex e6b5388..5ee0e80 100644[m
+[1m--- a/app/assets/stylesheets/components/_button.scss[m
+[1m+++ b/app/assets/stylesheets/components/_button.scss[m
+[36m@@ -84,5 +84,5 @@[m
+ }[m
+ [m
+ .button-synchroniser {[m
+[31m-  margin-top: 100px;[m
+[32m+[m[32m  margin-top: 40px;[m
+ }[m


### PR DESCRIPTION
Colonne Image créée lorsque j'ai voulu paramétrer l'affichage d'une image en fonction des genres musicaux affichés grâce à un each .. --> mauvaise méthode, donc la colonne Image ne sert plus à rien. 